### PR TITLE
Cameras update robot position

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -38,7 +38,7 @@ public class Robot extends CommandRobotBase
   private NetworkTableEntry nt_lift_setpoint;
 
   // TODO Use camera?
-  // private final CameraHelper camera_helper = new CameraHelper(tags);
+  private final CameraHelper camera_helper = new CameraHelper(tags);
 
   public Robot()
   {
@@ -86,7 +86,7 @@ public class Robot extends CommandRobotBase
 
     lift.setHeight(nt_lift_setpoint.getDouble(0.00));
     // TODO Update camera?
-    // camera_helper.updatePosition(drivetrain);
+    camera_helper.updatePosition(drivetrain);
   }
   @Override
   public void teleopInit()


### PR DESCRIPTION
In order for the position to be updated you must make sure that photon has a target or tele-op will be disabled. 
